### PR TITLE
Cut GVC before trying to detect structured details

### DIFF
--- a/lib/field86structure.js
+++ b/lib/field86structure.js
@@ -25,12 +25,17 @@ class Field86StructureParser {
    */
   static parse(details) {
     details = details.replace(/\n/g, '').trim();
-    const rule = Field86StructureParser.buildTagRe(details);
-    if (!rule) return;
-    if (!rule.detect.test(details)) return; // string must start with tag
 
     const parsedStruc = {};
 
+    if (details.match(/^\d\d\d[\?\>]/)) {
+      parsedStruc.gvc = details.substr(0,3);
+      details = details.substr(3);
+    }
+    
+    const rule = Field86StructureParser.buildTagRe(details);
+    if (!rule) return;
+    if (!rule.detect.test(details)) return; // string must start with tag
     let match = rule.match.exec(details);
     while (match) {
       const subTag = match[1].replace(rule.strip, '');


### PR DESCRIPTION
The details often contain a 3-digit GVC code at the beging of the details.
This should be parsed and cut before the details is checked for being structured.