### PR TITLE
do not discard spaces at line end

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -121,12 +121,7 @@ class Parser {
   */
   _splitAndNormalize(data) {
     return data
-      .split('\n')
-      .map(line => {
-        return line
-          .replace('\r', '')
-          .replace(/\s+$/, '');
-      })
+      .split(/\r?\n/)
       .filter(line => !!line && line !== '-');
   }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -142,8 +142,8 @@ describe('Parser', () => {
 
     it('_splitAndNormalize', () => {
       const parser = new Parser();
-      const result = parser._splitAndNormalize('abc   \r\n   \r\n-');
-      assert.deepEqual(result, ['abc']);
+      const result = parser._splitAndNormalize('abc   \r\n\r\n-');
+      assert.deepEqual(result, ['abc   ']);
     });
 
     it('_parseLines', () => {


### PR DESCRIPTION
A long "details" field may wrap over more than one line. A space
character right before the line wrap should not be discarded.